### PR TITLE
added character set meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8" />
         <title>Pat Stackz</title>
     </head>
     <body>


### PR DESCRIPTION
This pull request adds the code:

`<meta charset='utf-8' />`

to the document head. Specifying the character set to the “8-Bit Universal Character Set Transformation Format” mitigates XSS attacks and getting around URI validation.

Basically this goes in every HTML document, and the only time you might need to think about it is if you're trying to render special characters a certain way on screen, in which case we invoke the Unicode (ISO 10646) code for the character directly.

It's important, you see why I didn't bring it up when we'd just learned like eighty billion other things though 🤣